### PR TITLE
Show zone strengh as a number on the blip instead of scaling it.

### DIFF
--- a/src/persistence/saveable_objs/CustomTurfZone.cs
+++ b/src/persistence/saveable_objs/CustomTurfZone.cs
@@ -53,6 +53,7 @@ namespace GTA.GangAndTurfMod
                     {
                         areaBlip.Color = BlipColor.White;
                         areaBlip.Alpha = 60;
+                        myBlip.HideNumber();
                     }
                 }
                 else
@@ -69,7 +70,7 @@ namespace GTA.GangAndTurfMod
                         Function.Call(Hash.SET_BLIP_SECONDARY_COLOUR, myBlip, 255, 0f, 0f);
                     }
 
-                    myBlip.Scale = 1.0f + 0.65f / ((ModOptions.instance.maxTurfValue + 1) / ((float)value + 1));
+                    myBlip.ShowNumber(value);
 
                     if (areaBlip != null)
                     {

--- a/src/persistence/saveable_objs/TurfZone.cs
+++ b/src/persistence/saveable_objs/TurfZone.cs
@@ -64,6 +64,7 @@ namespace GTA.GangAndTurfMod
                 {
                     myBlip.Sprite = BlipSprite.GTAOPlayerSafehouseDead;
                     myBlip.Color = BlipColor.White;
+                    myBlip.HideNumber();
                 }
                 else
                 {
@@ -79,7 +80,7 @@ namespace GTA.GangAndTurfMod
                         Function.Call(Hash.SET_BLIP_SECONDARY_COLOUR, myBlip, 255, 0f, 0f);
                     }
 
-                    myBlip.Scale = 1.0f + 0.65f / ((ModOptions.instance.maxTurfValue + 1) / (float) (value + 1));
+                    myBlip.ShowNumber(value);
                 }
 
                 Function.Call(Hash.BEGIN_TEXT_COMMAND_SET_BLIP_NAME, "STRING");


### PR DESCRIPTION
This is a bit nicer and looks a lot cleaner than simply scaling the blips. 

![Screenshot_2021-07-09_10-20-37](https://user-images.githubusercontent.com/15368682/125092548-73abe880-e09f-11eb-8ab3-d1145b220941.png)
